### PR TITLE
Add BlogViewerPage and enable navigation from BlogCard

### DIFF
--- a/lib/features/blog/presentation/pages/blog_viewer_page.dart
+++ b/lib/features/blog/presentation/pages/blog_viewer_page.dart
@@ -1,0 +1,74 @@
+import 'package:blog_app/core/theme/app_pallete.dart';
+import 'package:blog_app/core/utils/calculate_reading_time.dart';
+import 'package:blog_app/core/utils/format_date.dart';
+import 'package:blog_app/features/blog/domain/entities/blog.dart';
+import 'package:flutter/material.dart';
+
+class BlogViewerPage extends StatelessWidget {
+  static route(Blog blog) => MaterialPageRoute(
+        builder: (context) => BlogViewerPage(
+          blog: blog,
+        ),
+      );
+  final Blog blog;
+  const BlogViewerPage({
+    super.key,
+    required this.blog,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: Scrollbar(
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  blog.title,
+                  style: const TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 20),
+                Text(
+                  'By ${blog.posterEmail}',
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w500,
+                    fontSize: 16,
+                  ),
+                ),
+                const SizedBox(height: 5),
+                Text(
+                  '${formatDateBydMMMYYYY(blog.updatedAt)} . ${calculateReadingTime(blog.description)} min',
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w500,
+                    color: AppPallete.greyColor,
+                    fontSize: 16,
+                  ),
+                ),
+                const SizedBox(height: 20),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(10),
+                  child: Image.network(blog.imageUrl),
+                ),
+                const SizedBox(height: 20),
+                Text(
+                  blog.description,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    height: 2,
+                  ),
+                )
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/blog/presentation/widgets/blog_card.dart
+++ b/lib/features/blog/presentation/widgets/blog_card.dart
@@ -1,5 +1,6 @@
 import 'package:blog_app/core/utils/calculate_reading_time.dart';
 import 'package:blog_app/features/blog/domain/entities/blog.dart';
+import 'package:blog_app/features/blog/presentation/pages/blog_viewer_page.dart';
 import 'package:flutter/material.dart';
 
 class BlogCard extends StatelessWidget {
@@ -14,7 +15,11 @@ class BlogCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () {},
+      onTap: () {
+        Navigator.of(context).push(BlogViewerPage.route(
+          blog,
+        ));
+      },
       child: Container(
         height: 200,
         margin: const EdgeInsets.all(16).copyWith(


### PR DESCRIPTION
This pull request adds a new `BlogViewerPage` widget and enables navigation from the `BlogCard` widget to the `BlogViewerPage`. The `BlogViewerPage` displays the details of a blog, including the title, author, date, reading time, image, and description. Users can now tap on a `BlogCard` to view the full blog content in the `BlogViewerPage`.